### PR TITLE
Add a background job to start loading plants when welcome page loads

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,5 +1,6 @@
 class WelcomeController < ApplicationController
   def index
+    PlantLoaderJob.perform_later
   end
 
 end

--- a/app/jobs/plant_loader_job.rb
+++ b/app/jobs/plant_loader_job.rb
@@ -1,0 +1,8 @@
+class PlantLoaderJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    PlantService.get_all_plants
+  end
+  
+end

--- a/spec/jobs/plant_loader_job_spec.rb
+++ b/spec/jobs/plant_loader_job_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe PlantLoaderJob, type: :job do
+
+  describe "#perform_later" do
+
+    it "loads all plant" do
+			
+      ActiveJob::Base.queue_adapter = :test
+        expect {
+          PlantLoaderJob.perform_later
+        }.to have_enqueued_job
+    end
+
+  end
+end
+


### PR DESCRIPTION
- added background job that starts loading all the plants when `welcome` page loads